### PR TITLE
Fix spec and Node typings

### DIFF
--- a/src/app/interceptors/loading-animation-interceptor/loading-animation.interceptor.spec.ts
+++ b/src/app/interceptors/loading-animation-interceptor/loading-animation.interceptor.spec.ts
@@ -1,14 +1,21 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpInterceptorFn } from '@angular/common/http';
+import { LoadingInterceptor } from './loading-animation.interceptor';
+import { LoadingAnimationService } from '../../services/loading-animation-service/loading-animation.service';
 
-import { loadingAnimationInterceptor } from './loading-animation.interceptor';
-
-describe('loadingAnimationInterceptor', () => {
-  const interceptor: HttpInterceptorFn = (req, next) => 
-    TestBed.runInInjectionContext(() => loadingAnimationInterceptor(req, next));
+describe('LoadingInterceptor', () => {
+  let interceptor: LoadingInterceptor;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const loadingServiceSpy = jasmine.createSpyObj('LoadingAnimationService', ['show', 'hide']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        LoadingInterceptor,
+        { provide: LoadingAnimationService, useValue: loadingServiceSpy }
+      ]
+    });
+
+    interceptor = TestBed.inject(LoadingInterceptor);
   });
 
   it('should be created', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,13 +20,16 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022",
-    "useDefineForClassFields": false,
-    "lib": [
-      "ES2022",
-      "dom"
-    ]
-  },
+      "module": "ES2022",
+      "useDefineForClassFields": false,
+      "lib": [
+        "ES2022",
+        "dom"
+      ],
+      "types": [
+        "node"
+      ]
+    },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
+      "jasmine",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary
- update interceptor spec to use class-based interceptor
- enable Node typings for unit tests

## Testing
- `npm test` *(fails: No binary for Chrome)*

